### PR TITLE
Reimplement the explicit FromRight and FromLeft methods

### DIFF
--- a/Monads.Test/Either_Tests.cs
+++ b/Monads.Test/Either_Tests.cs
@@ -52,7 +52,7 @@ namespace Monads.Test
          string value = "test";
          bool doRightInvoked = false;
 
-         var sut = Either<Unit, string>.From(value);
+         var sut = Either<Unit, string>.FromRight(value);
          sut.DoLeft(_ => Assert.Fail());
          sut.DoRight(right =>
          {
@@ -73,7 +73,7 @@ namespace Monads.Test
       [Test]
       public void FromRight_Returns_Bottom_If_Null_Provided()
       {
-         var sut = Either<Unit, string>.From(null);
+         var sut = Either<Unit, string>.FromRight(null);
          sut.DoLeft(_ => Assert.Fail());
          sut.DoRight(_ => Assert.Fail());
 
@@ -98,7 +98,7 @@ namespace Monads.Test
          int value = 5;
          bool doLeftInvoked = false;
 
-         var sut = Either<int, Unit>.From(value);
+         var sut = Either<int, Unit>.FromLeft(value);
          sut.DoLeft(left =>
          {
             doLeftInvoked = true;
@@ -119,7 +119,7 @@ namespace Monads.Test
       [Test]
       public void FromLeft_Returns_Bottom_If_Null_Provided()
       {
-         var sut = Either<object, Unit>.From(null);
+         var sut = Either<object, Unit>.FromLeft(null);
          sut.DoLeft(_ => Assert.Fail());
          sut.DoRight(_ => Assert.Fail());
 
@@ -145,7 +145,7 @@ namespace Monads.Test
          string value = "test";
          Task<string> task = Task.FromResult(value);
 
-         var eitherTask = Either<Unit, string>.FromAsync(task);
+         var eitherTask = Either<Unit, string>.FromRightAsync(task);
          var sut = await eitherTask;
 
          bool doRightInvoked = false;
@@ -172,7 +172,7 @@ namespace Monads.Test
          string value = null;
          Task<string> task = Task.FromResult(value);
 
-         var eitherTask = Either<Unit, string>.FromAsync(task);
+         var eitherTask = Either<Unit, string>.FromRightAsync(task);
          var sut = await eitherTask;
 
          sut.DoLeft(_ => Assert.Fail());
@@ -196,7 +196,7 @@ namespace Monads.Test
          string value = null;
          Task<string> task = Task.FromResult(value);
 
-         var eitherTask = Either<int, string>.FromAsync(task, 3);
+         var eitherTask = Either<int, string>.FromRightAsync(task, 3);
          var sut = await eitherTask;
 
          bool doLeftInvoked = true;

--- a/Monads/Either/Either.cs
+++ b/Monads/Either/Either.cs
@@ -41,30 +41,30 @@ namespace Monads
          }
       }
 
-      public static Either<TLeft, TRight> From(TRight value)
+      public static Either<TLeft, TRight> FromRight(TRight value)
       {
          return value is null
             ? FromBottom()
             : new Either<TLeft, TRight>(value);
       }
 
-      public static async Task<Either<TLeft, TRight>> FromAsync(Task<TRight> rightAsync)
+      public static async Task<Either<TLeft, TRight>> FromRightAsync(Task<TRight> rightAsync)
       {
          var right = await rightAsync;
          return right is null
             ? FromBottom()
-            : right;
+            : FromRight(right);
       }
 
-      public static async Task<Either<TLeft, TRight>> FromAsync(Task<TRight> rightAsync, TLeft left)
+      public static async Task<Either<TLeft, TRight>> FromRightAsync(Task<TRight> rightAsync, TLeft left)
       {
          var right = await rightAsync;
          return right is null
-            ? From(left)
-            : From(right);
+            ? FromLeft(left)
+            : FromRight(right);
       }
 
-      public static Either<TLeft, TRight> From(TLeft value)
+      public static Either<TLeft, TRight> FromLeft(TLeft value)
       {
          return value is null
             ? FromBottom()
@@ -183,7 +183,7 @@ namespace Monads
          return IsRight
             ? map(_right)
             : IsLeft
-               ? Either<TLeft, TResult>.From(_left)
+               ? Either<TLeft, TResult>.FromLeft(_left)
                : Either<TLeft, TResult>.FromBottom();
       }
 
@@ -197,7 +197,7 @@ namespace Monads
          return IsLeft
             ? map(_left)
             : IsRight
-               ? Either<TResult, TRight>.From(_right)
+               ? Either<TResult, TRight>.FromRight(_right)
                : Either<TResult, TRight>.FromBottom();
       }
 
@@ -211,7 +211,7 @@ namespace Monads
          return IsRight
             ? await mapAsync(_right)
             : IsLeft
-               ? Either<TLeft, TResult>.From(_left)
+               ? Either<TLeft, TResult>.FromLeft(_left)
                : Either<TLeft, TResult>.FromBottom();
       }
 
@@ -225,7 +225,7 @@ namespace Monads
          return IsRight
             ? bind(_right)
             : IsLeft
-               ? Either<TLeft, TResult>.From(_left)
+               ? Either<TLeft, TResult>.FromLeft(_left)
                : Either<TLeft, TResult>.FromBottom();
       }
 
@@ -239,7 +239,7 @@ namespace Monads
          return IsRight
             ? await bindAsync(_right)
             : IsLeft
-               ? Either<TLeft, TResult>.From(_left)
+               ? Either<TLeft, TResult>.FromLeft(_left)
                : Either<TLeft, TResult>.FromBottom();
       }
 
@@ -313,7 +313,7 @@ namespace Monads
 
       public Either<TLeft, TResult> SelectMany<TIntermediate, TResult>(Func<TRight, Either<TLeft, TIntermediate>> bind, Func<TRight, TIntermediate, TResult> project)
       {
-         return Bind(x => bind(x).Bind(y => Either<TLeft, TResult>.From(project(x, y))));
+         return Bind(x => bind(x).Bind(y => Either<TLeft, TResult>.FromRight(project(x, y))));
       }
 
       public Either<TLeft, TRight> Where(Func<TRight, bool> predicate)
@@ -328,8 +328,8 @@ namespace Monads
             : FromBottom();
       }
 
-      public static implicit operator Either<TLeft, TRight>(TLeft left) => From(left);
+      public static implicit operator Either<TLeft, TRight>(TLeft left) => FromLeft(left);
 
-      public static implicit operator Either<TLeft, TRight>(TRight right) => From(right);
+      public static implicit operator Either<TLeft, TRight>(TRight right) => FromRight(right);
    }
 }

--- a/Monads/Either/EitherAsyncExtensions.cs
+++ b/Monads/Either/EitherAsyncExtensions.cs
@@ -38,7 +38,7 @@ namespace Monads
       public static Task<Either<TLeft, TResult>> MapAsync<TLeft, TRight, TResult>(this Task<Either<TLeft, TRight>> either, Func<TRight, Task<Either<TLeft, TResult>>> map)
       {
          return either.MatchAsync(
-            left: left => Either<TLeft, TResult>.From(left),
+            left: left => Either<TLeft, TResult>.FromLeft(left),
             rightAsync: right => map(right));
       }
 
@@ -46,8 +46,8 @@ namespace Monads
       {
          return either.MapAsync(
                 async right =>
-                    await Either<TLeft, TRight>.From(right).MatchAsync(
-                       left => Either<TLeft, TResult>.From(left),
+                    await Either<TLeft, TRight>.FromRight(right).MatchAsync(
+                       left => Either<TLeft, TResult>.FromLeft(left),
                        async right2 => await bind(right2)));
       }
 
@@ -61,7 +61,7 @@ namespace Monads
       public static async Task<Either<TLeft, TResult>> Select<TLeft, TRight, TResult>(this Task<Either<TLeft, TRight>> either, Func<TRight, TResult> map)
       {
          return await either.MatchAsync(
-            Either<TLeft, TResult>.From,
+            Either<TLeft, TResult>.FromLeft,
             right => map(right));
       }
 
@@ -83,7 +83,7 @@ namespace Monads
             {
                return predicate(right)
                   ? right
-                  : Either<TLeft, TRight>.From(right);
+                  : Either<TLeft, TRight>.FromRight(right);
             });
       }
    }

--- a/Monads/Option/Option.cs
+++ b/Monads/Option/Option.cs
@@ -192,22 +192,22 @@ namespace Monads
       public Either<TLeft, TValue> ToEither<TLeft>(TLeft left)
       {
          return IsSome
-            ? Either<TLeft, TValue>.From(_value)
-            : Either<TLeft, TValue>.From(left);
+            ? Either<TLeft, TValue>.FromRight(_value)
+            : Either<TLeft, TValue>.FromLeft(left);
       }
 
       public Either<TValue, Unit> ToLeftEither()
       {
          return IsSome
-            ? Either<TValue, Unit>.From(_value)
-            : Either<TValue, Unit>.From(Unit.Default);
+            ? Either<TValue, Unit>.FromLeft(_value)
+            : Either<TValue, Unit>.FromRight(Unit.Default);
       }
 
       public Either<TValue, TRight> ToLeftEither<TRight>(TRight right)
       {
          return IsSome
-            ? Either<TValue, TRight>.From(_value)
-            : Either<TValue, TRight>.From(right);
+            ? Either<TValue, TRight>.FromLeft(_value)
+            : Either<TValue, TRight>.FromRight(right);
       }
 
       public Option<TResult> Select<TResult>(Func<TValue, TResult> map)

--- a/Monads/Option/OptionAsyncExtensions.cs
+++ b/Monads/Option/OptionAsyncExtensions.cs
@@ -40,7 +40,7 @@ namespace Monads
       {
          return option.MatchAsync(
             () => left,
-            value => Either<TLeft, TValue>.From(value));
+            value => Either<TLeft, TValue>.FromRight(value));
       }
 
       public static async Task<Option<TResult>> Select<TValue, TResult>(this Task<Option<TValue>> option, Func<TValue, TResult> map)


### PR DESCRIPTION
`null` could refer to either TLeft or TRight in case of classes or objects.  FromRight and FromLeft method naming clears up the ambiguity.